### PR TITLE
docs: add install step to vite-plugin-purge-icons

### DIFF
--- a/packages/vite-plugin-purge-icons/README.md
+++ b/packages/vite-plugin-purge-icons/README.md
@@ -10,6 +10,7 @@
 Install
 
 ```bash
+npm i @iconify/iconify
 npm i vite-plugin-purge-icons @iconify/json -D
 ```
 


### PR DESCRIPTION
The docs doesn't contain the dependency of iconify, which is needed to run the application