### PR TITLE
fix: add exports field in package.json

### DIFF
--- a/packages/@purge-icons/core/package.json
+++ b/packages/@purge-icons/core/package.json
@@ -4,6 +4,10 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js"
+  },
   "license": "MIT",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "repository": {

--- a/packages/@purge-icons/generated/package.json
+++ b/packages/@purge-icons/generated/package.json
@@ -5,6 +5,10 @@
   "main": "index.js",
   "module": "index.mjs",
   "types": "index.d.js",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js"
+  },
   "license": "MIT",
   "publishConfig": {
     "access": "public"

--- a/packages/gridsome-plugin-purge-icons/package.json
+++ b/packages/gridsome-plugin-purge-icons/package.json
@@ -5,6 +5,10 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js"
+  },
   "keywords": [
     "gridsome-loader",
     "purge-icons"

--- a/packages/next-purge-icons/package.json
+++ b/packages/next-purge-icons/package.json
@@ -5,6 +5,10 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js"
+  },
   "keywords": [
     "vue-cli-plugin",
     "purge-icons"

--- a/packages/parcel-plugin-purge-icons/package.json
+++ b/packages/parcel-plugin-purge-icons/package.json
@@ -5,6 +5,10 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js"
+  },
   "keywords": [
     "parcel-plugin",
     "purge-icons"

--- a/packages/purge-icons-webpack-plugin/package.json
+++ b/packages/purge-icons-webpack-plugin/package.json
@@ -5,6 +5,10 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js"
+  },
   "keywords": [
     "webpack-plugin",
     "purge-icons"

--- a/packages/purge-icons/package.json
+++ b/packages/purge-icons/package.json
@@ -5,6 +5,10 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js"
+  },
   "license": "MIT",
   "author": "Anthony Fu <anthonyfu117@hotmail.com>",
   "repository": {

--- a/packages/rollup-plugin-purge-icons/package.json
+++ b/packages/rollup-plugin-purge-icons/package.json
@@ -5,6 +5,10 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js"
+  },
   "keywords": [
     "rollup-plugin",
     "purge-icons"

--- a/packages/vite-plugin-purge-icons/package.json
+++ b/packages/vite-plugin-purge-icons/package.json
@@ -4,6 +4,10 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js"
+  },
   "license": "MIT",
   "author": "antfu <anthonyfu117@hotmail.com>",
   "repository": {

--- a/packages/vue-cli-plugin-purge-icons/package.json
+++ b/packages/vue-cli-plugin-purge-icons/package.json
@@ -5,6 +5,10 @@
   "main": "dist/index.js",
   "module": "dist/index.mjs",
   "types": "dist/index.d.ts",
+  "exports": {
+    "import": "./dist/index.mjs",
+    "require": "./dist/index.js"
+  },
   "keywords": [
     "vue-cli-plugin",
     "purge-icons"


### PR DESCRIPTION
From vite@2.0.0-beta.22, vite uses native esm imports in `vite.config.js` when `"type": "module"` is set in package.json of the project.

This PR adds `exports` field to every package.

Adding this to `rollup-plugin-purge-icons` and `vite-plugin-purge-icons` fixed the error in the situation above.
```
failed to load config from /documents/GitHub/portfolio/vite.config.ts
error when starting dev server:
TypeError: PurgeIcons is not a function
    at file:///D:/documents/GitHub/portfolio/vite.config.ts.js?t=1611041039388:34:5
    at ModuleJob.run (internal/modules/esm/module_job.js:152:23)
    at async Loader.import (internal/modules/esm/loader.js:166:24)
    at async loadConfigFromFile (D:\documents\GitHub\portfolio\node_modules\vite\dist\node\chunks\dep-b51e3b62.js:46921:31)
    at async resolveConfig (D:\documents\GitHub\portfolio\node_modules\vite\dist\node\chunks\dep-b51e3b62.js:46710:28)
    at async createServer$2 (D:\documents\GitHub\portfolio\node_modules\vite\dist\node\chunks\dep-b51e3b62.js:70324:20)
    at async CAC.<anonymous> (D:\documents\GitHub\portfolio\node_modules\vite\dist\node\cli.js:683:24)
```

(I have not tested other packages but I think it would work.)

Another way to fix this is to change the transpile somehow.
The reason of this error is that `export default`'s are been transpiled to `export.default = ` instead of `module.exports = `.
https://github.com/egoist/tsup/blob/f0a833976b99bdd2df0d704b636f370963751eb7/src/index.ts#L204
https://sucrase.io/#selectedTransforms=imports&compareWithTypeScript=true&code=const%20App%20%3D%20%7B%7D%0A%0Aexport%20default%20App%3B%0A%0A
