### PR TITLE
feat: support loading from `@iconify-json/*`

### DIFF
--- a/packages/@purge-icons/core/src/loader.ts
+++ b/packages/@purge-icons/core/src/loader.ts
@@ -18,6 +18,17 @@ export async function fetchCollection(
 
   if (source === 'local' || source === 'auto') {
     try {
+      const { icons: collection } = await import (`@iconify-json/${name}`)
+      cache[name] = collection
+      // If an error is reported, it will not be printed here
+      debug(`fetching collection "${name}" from local packages`)
+      return collection
+    }
+    catch (e) {
+      // try to import from `@iconify/json` so do nothing here
+    }
+
+    try {
       debug(`fetching collection "${name}" from local packages`)
       const collection = await import(`@iconify/json/json/${name}.json`)
       cache[name] = collection


### PR DESCRIPTION
As you said, the complete `@iconify-json` dependency package is up to 130MB, but most of the time we don't use all `iconSet`, maybe only one or two of them, but we still need to do this Relying on the huge `@iconify-json`, we don't actually use other icons, which leads to a lot of useless icon set files in our `node_modules` dependency environment, which will lead to larger size.

Thanks to the good design for iconfig, we can download the `Individual icon sets` we need individually, so I think we can try to import the package Individual icon sets (`@iconify- json/[the-collection-you-want]`), which makes it easier for users to install the desired chart collection.